### PR TITLE
Cabinet address and contacts modules improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "react-scripts": "^5.0.1",
     "sass": "^1.57.1",
     "styled-components": "^5.3.9",
+    "uuid": "^9.0.1",
     "web-vitals": "^2.1.4",
     "yup": "^1.2.0"
   },
@@ -45,6 +46,7 @@
     "@types/react": "^18.0.31",
     "@types/react-dom": "^18.0.11",
     "@types/styled-components": "^5.1.26",
+    "@types/uuid": "^9.0.7",
     "@types/yup": "^0.32.0",
     "@typescript-eslint/eslint-plugin": "^5.57.0",
     "@typescript-eslint/parser": "^5.57.0",

--- a/public/index.html
+++ b/public/index.html
@@ -3,10 +3,7 @@
 
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta name="viewport" content="width=device-width; initial-scale=1" />
-  <!-- <link rel="stylesheet" href="css/all.css" type="text/css" /> -->
-  <!-- <link rel="stylesheet" href="css/fonts.css" type="text/css" /> -->
-  <!-- <script type="text/javascript" src="js/main.js"></script> -->
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Aethetics</title>
 </head>
 

--- a/src/constants/storageKeys.ts
+++ b/src/constants/storageKeys.ts
@@ -1,6 +1,7 @@
 const STORAGE_KEYS = {
   basket: 'basket',
-  address: 'address'
+  address: 'address',
+  contacts: 'contacts'
 };
 
 export default STORAGE_KEYS;

--- a/src/modules/cabinet/components/Address/CabinetAddress.tsx
+++ b/src/modules/cabinet/components/Address/CabinetAddress.tsx
@@ -14,6 +14,9 @@ const CabinetAddress: React.FC = () => {
   const removeHandler = (uuid: string) => {
     addressService.remove(uuid);
     setAddresses(addressService.addresses);
+    if (updateAddress?.uuid === uuid) {
+      setUpdateAddress(null);
+    }
   };
   const updateHandler = (address: IAddress) => {
     setUpdateAddress(address);

--- a/src/modules/cabinet/components/Address/CabinetAddress.tsx
+++ b/src/modules/cabinet/components/Address/CabinetAddress.tsx
@@ -25,9 +25,8 @@ const CabinetAddress: React.FC = () => {
           Контактна інформація
         </Link>
       </Styled.MobileTab>
-
       <Styled.MobileTabContent>
-        <Styled.MobileTab>Адресна книга</Styled.MobileTab>
+        <Styled.MobileTab $active>Адресна книга</Styled.MobileTab>
         <Styled.Flex>
           {addresses.length > 0 && (
             <Styled.LeftColumn>

--- a/src/modules/cabinet/components/Address/CabinetAddress.tsx
+++ b/src/modules/cabinet/components/Address/CabinetAddress.tsx
@@ -37,6 +37,7 @@ const CabinetAddress: React.FC = () => {
                   updateHandler={updateHandler}
                   key={idx}
                   address={address}
+                  updating={address.uuid === updateAddress?.uuid}
                 />
               ))}
             </Styled.LeftColumn>

--- a/src/modules/cabinet/components/Address/CabinetAddress.tsx
+++ b/src/modules/cabinet/components/Address/CabinetAddress.tsx
@@ -11,8 +11,8 @@ import { IAddress } from '../../../../types/address';
 const CabinetAddress: React.FC = () => {
   const [addresses, setAddresses] = useState(addressService.addresses);
   const [updateAddress, setUpdateAddress] = useState<IAddress | null>(null);
-  const removeHandler = (id: number) => {
-    addressService.remove(id);
+  const removeHandler = (uuid: string) => {
+    addressService.remove(uuid);
     setAddresses(addressService.addresses);
   };
   const updateHandler = (address: IAddress) => {

--- a/src/modules/cabinet/components/Address/CabinetAddressBlock.styled.ts
+++ b/src/modules/cabinet/components/Address/CabinetAddressBlock.styled.ts
@@ -4,12 +4,21 @@ import { COLORS, FONTS, MEDIA } from '../../../theme';
 export const Item = styled.div`
   width: 100%;
   position: relative;
-  padding-left: 60px;
   margin-bottom: 20px;
+  padding: 8px 8px 8px 60px;
   @media (max-width: ${MEDIA.tablet}px) {
     width: unset;
-    padding-left: 35px;
+    padding: 4px 4px 4px 35px;
+
     margin-bottom: 0;
+  }
+  &.updating {
+    box-shadow: rgb(255, 255, 255, 1) 52px 0px 0px 0px inset,
+      rgba(255, 255, 0, 0.2) -315px 0px 0px 0px inset;
+    @media (max-width: ${MEDIA.tablet}px) {
+      box-shadow: rgb(255, 255, 255, 1) 32px 0px 0px 0px inset,
+        rgba(255, 255, 0, 0.2) -400px 0px 0px 0px inset;
+    }
   }
 `;
 export const Index = styled.div`

--- a/src/modules/cabinet/components/Address/CabinetAddressBlock.styled.ts
+++ b/src/modules/cabinet/components/Address/CabinetAddressBlock.styled.ts
@@ -1,24 +1,21 @@
 import styled from 'styled-components';
 import { COLORS, FONTS, MEDIA } from '../../../theme';
 
-export const Item = styled.div`
+export const Item = styled.div<{ $updating?: boolean }>`
   width: 100%;
   position: relative;
   margin-bottom: 20px;
   padding: 8px 8px 8px 60px;
+  box-shadow: ${(props) =>
+    props.$updating &&
+    'rgb(255, 255, 255, 1) 52px 0px 0px 0px inset, rgba(255, 255, 0, 0.2) -315px 0px 0px 0px inset;'};
   @media (max-width: ${MEDIA.tablet}px) {
     width: unset;
     padding: 4px 4px 4px 35px;
-
     margin-bottom: 0;
-  }
-  &.updating {
-    box-shadow: rgb(255, 255, 255, 1) 52px 0px 0px 0px inset,
-      rgba(255, 255, 0, 0.2) -315px 0px 0px 0px inset;
-    @media (max-width: ${MEDIA.tablet}px) {
-      box-shadow: rgb(255, 255, 255, 1) 32px 0px 0px 0px inset,
-        rgba(255, 255, 0, 0.2) -400px 0px 0px 0px inset;
-    }
+    box-shadow: ${(props) =>
+      props.$updating &&
+      'rgb(255, 255, 255, 1) 32px 0px 0px 0px inset, rgba(255, 255, 0, 0.2) -400px 0px 0px 0px inset;'};
   }
 `;
 export const Index = styled.div`

--- a/src/modules/cabinet/components/Address/CabinetAddressBlock.tsx
+++ b/src/modules/cabinet/components/Address/CabinetAddressBlock.tsx
@@ -6,10 +6,16 @@ interface IProps {
   address: IAddress;
   removeHandler(uuid: string): void;
   updateHandler(address: IUpdateAddress): void;
+  updating: boolean;
 }
 
-const CabinetAddressBlock: React.FC<IProps> = ({ address, removeHandler, updateHandler }) => (
-  <Styled.Item>
+const CabinetAddressBlock: React.FC<IProps> = ({
+  address,
+  removeHandler,
+  updateHandler,
+  updating = false
+}) => (
+  <Styled.Item className={updating ? 'updating' : ''}>
     <Styled.Index>{address.id}</Styled.Index>
     <Styled.Text>{address.city}</Styled.Text>
     <Styled.Text>

--- a/src/modules/cabinet/components/Address/CabinetAddressBlock.tsx
+++ b/src/modules/cabinet/components/Address/CabinetAddressBlock.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import * as Styled from './CabinetAddressBlock.styled';
-import { IAddress } from '../../../../types/address';
+import { IAddress, IUpdateAddress } from '../../../../types/address';
 
 interface IProps {
   address: IAddress;
-  removeHandler(id: number): void;
-  updateHandler(address: IAddress): void;
+  removeHandler(uuid: string): void;
+  updateHandler(address: IUpdateAddress): void;
 }
 
 const CabinetAddressBlock: React.FC<IProps> = ({ address, removeHandler, updateHandler }) => (
@@ -20,7 +20,7 @@ const CabinetAddressBlock: React.FC<IProps> = ({ address, removeHandler, updateH
       <Styled.Button type="button" onClick={() => updateHandler(address)}>
         Редагувати
       </Styled.Button>
-      <Styled.Button type="button" onClick={() => removeHandler(address.id)}>
+      <Styled.Button type="button" onClick={() => removeHandler(address.uuid)}>
         Видалити
       </Styled.Button>
     </Styled.ButtonsContainer>

--- a/src/modules/cabinet/components/Address/CabinetAddressBlock.tsx
+++ b/src/modules/cabinet/components/Address/CabinetAddressBlock.tsx
@@ -15,7 +15,7 @@ const CabinetAddressBlock: React.FC<IProps> = ({
   updateHandler,
   updating = false
 }) => (
-  <Styled.Item className={updating ? 'updating' : ''}>
+  <Styled.Item $updating={updating}>
     <Styled.Index>{address.id}</Styled.Index>
     <Styled.Text>{address.city}</Styled.Text>
     <Styled.Text>

--- a/src/modules/cabinet/components/Address/CabinetAddressBlock.tsx
+++ b/src/modules/cabinet/components/Address/CabinetAddressBlock.tsx
@@ -19,7 +19,8 @@ const CabinetAddressBlock: React.FC<IProps> = ({
     <Styled.Index>{address.id}</Styled.Index>
     <Styled.Text>{address.city}</Styled.Text>
     <Styled.Text>
-      {address.street}, {address.house} {address.apartment ? ` ,${address.apartment}` : ''}
+      {address.street} {address.house}
+      {address.apartment ? `, ${address.apartment}` : ''}
     </Styled.Text>
     <Styled.Text>{address.postal}</Styled.Text>
     <Styled.ButtonsContainer>

--- a/src/modules/cabinet/components/Address/CabinetAddressForm.tsx
+++ b/src/modules/cabinet/components/Address/CabinetAddressForm.tsx
@@ -3,7 +3,7 @@ import { Field, Form, Formik } from 'formik';
 import * as Styled from './CabinetAddressForm.styled';
 import { Button as StyledButton } from '../../../common/button/button.styled';
 import { addressValidationSchema } from '../../../../schemas/address.schema';
-import { IAddNewAddress, IAddress } from '../../../../types/address';
+import { IAddNewAddress, IAddress, IUpdateAddress } from '../../../../types/address';
 import addressService from '../../../../services/address.service';
 
 interface IProps {
@@ -37,7 +37,7 @@ export const CabinetAddressForm: React.FC<IProps> = ({
           const newAddress: IAddNewAddress = { ...values };
           addressService.add(newAddress);
         } else {
-          const updatedAddress: IAddress = { id: updateAddress.id, ...values };
+          const updatedAddress: IUpdateAddress = { uuid: updateAddress.uuid, ...values };
           addressService.update(updatedAddress);
         }
         setAddresses(addressService.addresses);

--- a/src/modules/cabinet/components/Address/CabinetAddressForm.tsx
+++ b/src/modules/cabinet/components/Address/CabinetAddressForm.tsx
@@ -32,7 +32,7 @@ export const CabinetAddressForm: React.FC<IProps> = ({
       enableReinitialize
       initialValues={initialValues}
       validationSchema={addressValidationSchema}
-      onSubmit={(values, { setSubmitting }) => {
+      onSubmit={(values, { setSubmitting, resetForm }) => {
         if (updateAddress === null) {
           const newAddress: IAddNewAddress = { ...values };
           addressService.add(newAddress);
@@ -43,6 +43,7 @@ export const CabinetAddressForm: React.FC<IProps> = ({
         setAddresses(addressService.addresses);
         setSubmitting(false);
         setUpdateAddress(null);
+        resetForm();
       }}
     >
       {({ isSubmitting, errors, touched }) => (

--- a/src/modules/cabinet/components/Address/CabinetAddressForm.tsx
+++ b/src/modules/cabinet/components/Address/CabinetAddressForm.tsx
@@ -61,6 +61,7 @@ export const CabinetAddressForm: React.FC<IProps> = ({
               name="city"
               placeholder="Місто"
               required
+              autocomplete="shiping city address-level2"
             />
 
             <Styled.InputGroup>
@@ -71,6 +72,7 @@ export const CabinetAddressForm: React.FC<IProps> = ({
                 name="street"
                 placeholder="Вулиця"
                 required
+                autocomplete="shiping street address-level3"
               />
 
               <Field
@@ -80,6 +82,7 @@ export const CabinetAddressForm: React.FC<IProps> = ({
                 name="house"
                 placeholder="Корпус"
                 required
+                autocomplete="shiping address-level4"
               />
 
               <Field
@@ -98,6 +101,7 @@ export const CabinetAddressForm: React.FC<IProps> = ({
               id="postal"
               placeholder="Поштове відділення або індекс"
               required
+              autocomplete="shipping postal-code"
             />
 
             <Styled.ButtonContainer>

--- a/src/modules/cabinet/components/Contacts/CabinetContacts.tsx
+++ b/src/modules/cabinet/components/Contacts/CabinetContacts.tsx
@@ -11,7 +11,7 @@ const CabinetContacts: React.FC = () => {
   const [updating, setUpdating] = useState(false);
   return (
     <>
-      <Styled.MobileTab className="active">Контактна інформація</Styled.MobileTab>
+      <Styled.MobileTab $active>Контактна інформація</Styled.MobileTab>
       <Styled.MobileTabContent>
         {contacts && contacts.name.length > 0 ? (
           updating ? (

--- a/src/modules/cabinet/components/Contacts/CabinetContacts.tsx
+++ b/src/modules/cabinet/components/Contacts/CabinetContacts.tsx
@@ -8,18 +8,24 @@ import contactsService from '../../../../services/contacts.service';
 
 const CabinetContacts: React.FC = () => {
   const [contacts, setContacts] = useState(contactsService.contacts);
+  const [updating, setUpdating] = useState(false);
   return (
     <>
       <Styled.MobileTab className="active">Контактна інформація</Styled.MobileTab>
       <Styled.MobileTabContent>
-        <CabinetContactsForm setContacts={setContacts} />
-        <CabinetContactsFilled
-          name={contacts.name}
-          surname={contacts.surname}
-          email={contacts.email}
-          tel={contacts.tel}
-          dob={contacts.dob}
-        />
+        {contacts && contacts.name.length > 0 ? (
+          updating ? (
+            <CabinetContactsForm
+              setContacts={setContacts}
+              setUpdating={setUpdating}
+              initialValues={contacts}
+            />
+          ) : (
+            <CabinetContactsFilled contacts={contacts} setUpdating={setUpdating} />
+          )
+        ) : (
+          <CabinetContactsForm setContacts={setContacts} setUpdating={setUpdating} />
+        )}
       </Styled.MobileTabContent>
       <Styled.MobileTab>
         <Link to={`/${ROUTER_KEYS.cabinet.root}/${ROUTER_KEYS.cabinet.address}`}>

--- a/src/modules/cabinet/components/Contacts/CabinetContacts.tsx
+++ b/src/modules/cabinet/components/Contacts/CabinetContacts.tsx
@@ -1,37 +1,43 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { ROUTER_KEYS } from '../../../../constants/routerKeys';
 import { CabinetContactsFilled } from './CabinetContactsFilled';
 import { CabinetContactsForm } from './CabinetContactsForm';
 import * as Styled from '../../pages/Cabinet.styled';
+import contactsService from '../../../../services/contacts.service';
 
-const CabinetContacts: React.FC = () => (
-  <>
-    <Styled.MobileTab className="active">Контактна інформація</Styled.MobileTab>
-    <Styled.MobileTabContent>
-      <CabinetContactsForm />
-      <CabinetContactsFilled
-        name="Оксана"
-        surname="Кінь"
-        email="supersanta@gmail.com"
-        phone="+380 66 329 97 45"
-        dob="12.10.1999"
-      />
-    </Styled.MobileTabContent>
-    <Styled.MobileTab>
-      <Link to={`/${ROUTER_KEYS.cabinet.root}/${ROUTER_KEYS.cabinet.address}`}>Адресна книга</Link>
-    </Styled.MobileTab>
-    <Styled.MobileTab>
-      <Link to={`/${ROUTER_KEYS.cabinet.root}/${ROUTER_KEYS.cabinet.favourites}`}>
-        Список бажань
-      </Link>
-    </Styled.MobileTab>
-    <Styled.MobileTab>
-      <Link to={`/${ROUTER_KEYS.cabinet.root}/${ROUTER_KEYS.cabinet.history}`}>
-        Історія замовлень
-      </Link>
-    </Styled.MobileTab>
-  </>
-);
+const CabinetContacts: React.FC = () => {
+  const [contacts, setContacts] = useState(contactsService.contacts);
+  return (
+    <>
+      <Styled.MobileTab className="active">Контактна інформація</Styled.MobileTab>
+      <Styled.MobileTabContent>
+        <CabinetContactsForm setContacts={setContacts} />
+        <CabinetContactsFilled
+          name={contacts.name}
+          surname={contacts.surname}
+          email={contacts.email}
+          tel={contacts.tel}
+          dob={contacts.dob}
+        />
+      </Styled.MobileTabContent>
+      <Styled.MobileTab>
+        <Link to={`/${ROUTER_KEYS.cabinet.root}/${ROUTER_KEYS.cabinet.address}`}>
+          Адресна книга
+        </Link>
+      </Styled.MobileTab>
+      <Styled.MobileTab>
+        <Link to={`/${ROUTER_KEYS.cabinet.root}/${ROUTER_KEYS.cabinet.favourites}`}>
+          Список бажань
+        </Link>
+      </Styled.MobileTab>
+      <Styled.MobileTab>
+        <Link to={`/${ROUTER_KEYS.cabinet.root}/${ROUTER_KEYS.cabinet.history}`}>
+          Історія замовлень
+        </Link>
+      </Styled.MobileTab>
+    </>
+  );
+};
 
 export default CabinetContacts;

--- a/src/modules/cabinet/components/Contacts/CabinetContacts.tsx
+++ b/src/modules/cabinet/components/Contacts/CabinetContacts.tsx
@@ -8,23 +8,28 @@ import contactsService from '../../../../services/contacts.service';
 
 const CabinetContacts: React.FC = () => {
   const [contacts, setContacts] = useState(contactsService.contacts);
-  const [updating, setUpdating] = useState(false);
+  const [isUpdating, setIsUpdating] = useState(false);
   return (
     <>
       <Styled.MobileTab $active>Контактна інформація</Styled.MobileTab>
       <Styled.MobileTabContent>
         {contacts && contacts.name.length > 0 ? (
-          updating ? (
+          isUpdating ? (
             <CabinetContactsForm
               setContacts={setContacts}
-              setUpdating={setUpdating}
+              isUpdating={isUpdating}
+              setIsUpdating={setIsUpdating}
               initialValues={contacts}
             />
           ) : (
-            <CabinetContactsFilled contacts={contacts} setUpdating={setUpdating} />
+            <CabinetContactsFilled contacts={contacts} setIsUpdating={setIsUpdating} />
           )
         ) : (
-          <CabinetContactsForm setContacts={setContacts} setUpdating={setUpdating} />
+          <CabinetContactsForm
+            setContacts={setContacts}
+            isUpdating={isUpdating}
+            setIsUpdating={setIsUpdating}
+          />
         )}
       </Styled.MobileTabContent>
       <Styled.MobileTab>

--- a/src/modules/cabinet/components/Contacts/CabinetContactsFilled.tsx
+++ b/src/modules/cabinet/components/Contacts/CabinetContactsFilled.tsx
@@ -3,32 +3,39 @@ import { IContacts } from '../../../../types/contacts';
 import { Button } from '../../../common/button/button.styled';
 import * as Styled from './CabinetContactsFilled.styled';
 
-export const CabinetContactsFilled: React.FC<IContacts> = ({ name, surname, email, tel, dob }) => (
+interface IProps {
+  contacts: IContacts;
+  setUpdating: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+export const CabinetContactsFilled: React.FC<IProps> = ({ contacts, setUpdating }) => (
   <>
     <Styled.Grid>
       <Styled.Container>
         <Styled.Label>Ім’я:</Styled.Label>
-        <Styled.Text>{name}</Styled.Text>
+        <Styled.Text>{contacts.name}</Styled.Text>
       </Styled.Container>
       <Styled.Container>
         <Styled.Label>Прізвище:</Styled.Label>
-        <Styled.Text>{surname}</Styled.Text>
+        <Styled.Text>{contacts.surname}</Styled.Text>
       </Styled.Container>
       <Styled.Container>
         <Styled.Label>E-mail:</Styled.Label>
-        <Styled.Text>{email}</Styled.Text>
+        <Styled.Text>{contacts.email}</Styled.Text>
       </Styled.Container>
       <Styled.Container>
         <Styled.Label>Номер телефону:</Styled.Label>
-        <Styled.Text>{tel}</Styled.Text>
+        <Styled.Text>{contacts.tel}</Styled.Text>
       </Styled.Container>
       <Styled.Container>
         <Styled.Label>Дата народження:</Styled.Label>
-        <Styled.Text>{dob || ''}</Styled.Text>
+        <Styled.Text>{contacts.dob || ''}</Styled.Text>
       </Styled.Container>
     </Styled.Grid>
     <Styled.BtnContainer>
-      <Button type="submit">Редагувати</Button>
+      <Button type="button" onClick={() => setUpdating(true)}>
+        Редагувати
+      </Button>
     </Styled.BtnContainer>
   </>
 );

--- a/src/modules/cabinet/components/Contacts/CabinetContactsFilled.tsx
+++ b/src/modules/cabinet/components/Contacts/CabinetContactsFilled.tsx
@@ -5,10 +5,10 @@ import * as Styled from './CabinetContactsFilled.styled';
 
 interface IProps {
   contacts: IContacts;
-  setUpdating: React.Dispatch<React.SetStateAction<boolean>>;
+  setIsUpdating: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-export const CabinetContactsFilled: React.FC<IProps> = ({ contacts, setUpdating }) => (
+export const CabinetContactsFilled: React.FC<IProps> = ({ contacts, setIsUpdating }) => (
   <>
     <Styled.Grid>
       <Styled.Container>
@@ -33,7 +33,7 @@ export const CabinetContactsFilled: React.FC<IProps> = ({ contacts, setUpdating 
       </Styled.Container>
     </Styled.Grid>
     <Styled.BtnContainer>
-      <Button type="button" onClick={() => setUpdating(true)}>
+      <Button type="button" onClick={() => setIsUpdating(true)}>
         Редагувати
       </Button>
     </Styled.BtnContainer>

--- a/src/modules/cabinet/components/Contacts/CabinetContactsFilled.tsx
+++ b/src/modules/cabinet/components/Contacts/CabinetContactsFilled.tsx
@@ -1,16 +1,9 @@
 import React from 'react';
+import { IContacts } from '../../../../types/contacts';
 import { Button } from '../../../common/button/button.styled';
 import * as Styled from './CabinetContactsFilled.styled';
 
-interface IProps {
-  name: string;
-  surname: string;
-  email: string;
-  phone: string;
-  dob: string;
-}
-
-export const CabinetContactsFilled: React.FC<IProps> = ({ name, surname, email, phone, dob }) => (
+export const CabinetContactsFilled: React.FC<IContacts> = ({ name, surname, email, tel, dob }) => (
   <>
     <Styled.Grid>
       <Styled.Container>
@@ -27,11 +20,11 @@ export const CabinetContactsFilled: React.FC<IProps> = ({ name, surname, email, 
       </Styled.Container>
       <Styled.Container>
         <Styled.Label>Номер телефону:</Styled.Label>
-        <Styled.Text>{phone}</Styled.Text>
+        <Styled.Text>{tel}</Styled.Text>
       </Styled.Container>
       <Styled.Container>
         <Styled.Label>Дата народження:</Styled.Label>
-        <Styled.Text>{dob}</Styled.Text>
+        <Styled.Text>{dob || ''}</Styled.Text>
       </Styled.Container>
     </Styled.Grid>
     <Styled.BtnContainer>

--- a/src/modules/cabinet/components/Contacts/CabinetContactsForm.styled.ts
+++ b/src/modules/cabinet/components/Contacts/CabinetContactsForm.styled.ts
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import { COLORS, FONTS, MEDIA } from '../../../theme';
 
-export const Form = styled.form`
+export const Wrapper = styled.div`
   max-width: 1016px;
   margin: 0 auto;
   position: relative;
@@ -81,3 +81,4 @@ export const SubmitBtnContainer = styled.div`
     margin-top: -42px;
   }
 `;
+export const Error = styled.span``;

--- a/src/modules/cabinet/components/Contacts/CabinetContactsForm.tsx
+++ b/src/modules/cabinet/components/Contacts/CabinetContactsForm.tsx
@@ -1,39 +1,70 @@
+import { Field, Form, Formik } from 'formik';
 import React from 'react';
-
+import { contactsValidationSchema } from '../../../../schemas/contacts.schema';
+import contactsService from '../../../../services/contacts.service';
+import { IContacts } from '../../../../types/contacts';
 import {
   Button as StyledButton,
   ButtonArrowRight as StyledButtonArrowRight
 } from '../../../common/button/button.styled';
 import * as Styled from './CabinetContactsForm.styled';
 
-export const CabinetContactsForm: React.FC = () => (
-  <Styled.Form action="post" className="for-contacts">
-    <Styled.Flex>
-      <Styled.Column>
-        <label htmlFor="name">Ваше ім’я</label>
-        <input type="text" className="name" id="name" placeholder="Світлана" />
-        <label htmlFor="surname">Ваше прізвище</label>
-        <input type="text" className="surname" id="surname" placeholder="Світлана" />
-        <label htmlFor="email">E-mail</label>
-        <input type="email" className="email" id="email" placeholder="shevSv002@gmail.com" />
-      </Styled.Column>
-      <Styled.Column>
-        <label htmlFor="telephone">Номер телефону</label>
-        <input
-          type="telephone"
-          className="telephone"
-          id="telephone"
-          placeholder="+38 068 564 77 99"
-        />
-        <label htmlFor="date-of-birth">Дата народження</label>
-        <input type="text" className="date-of-birth" id="date-of-birth" placeholder="8.10.1989" />
-        <Styled.ExitBtnContainer>
-          <StyledButtonArrowRight>Вийти</StyledButtonArrowRight>
-        </Styled.ExitBtnContainer>
-      </Styled.Column>
-    </Styled.Flex>
-    <Styled.SubmitBtnContainer>
-      <StyledButton type="submit">Зберегти</StyledButton>
-    </Styled.SubmitBtnContainer>
-  </Styled.Form>
+interface IProps {
+  setContacts: React.Dispatch<React.SetStateAction<IContacts>>;
+}
+
+export const CabinetContactsForm: React.FC<IProps> = ({ setContacts }) => (
+  <Formik
+    initialValues={{
+      name: '',
+      surname: '',
+      tel: '',
+      email: '',
+      dob: ''
+    }}
+    validationSchema={contactsValidationSchema}
+    onSubmit={(values, { setSubmitting }) => {
+      const newContact = { ...values };
+      contactsService.contacts = newContact;
+      console.log(values);
+      setSubmitting(false);
+      setContacts(contactsService.contacts);
+    }}
+  >
+    {({ isSubmitting, errors, touched }) => (
+      <Form>
+        <Styled.Wrapper className="for-contacts">
+          <Styled.Flex>
+            <Styled.Column>
+              <label htmlFor="name">Ваше ім’я</label>
+              <Field type="text" name="name" id="name" placeholder="Світлана" />
+              <label htmlFor="surname">Ваше прізвище</label>
+              <Field type="text" name="surname" id="surname" placeholder="Світлана" />
+              <label htmlFor="email">E-mail</label>
+              <Field type="email" name="email" id="email" placeholder="shevSv002@gmail.com" />
+            </Styled.Column>
+            <Styled.Column>
+              <label htmlFor="tel">Номер телефону</label>
+              <Field type="tel" name="tel" id="tel" placeholder="+38 068 564 77 99" />
+              <label htmlFor="dob">Дата народження</label>
+              <Field type="text" name="dob" id="dob" placeholder="8.10.1989" />
+              <Styled.ExitBtnContainer>
+                <StyledButtonArrowRight>Вийти</StyledButtonArrowRight>
+              </Styled.ExitBtnContainer>
+            </Styled.Column>
+          </Styled.Flex>
+          <Styled.SubmitBtnContainer>
+            <StyledButton type="submit" disabled={isSubmitting}>
+              Зберегти
+            </StyledButton>
+          </Styled.SubmitBtnContainer>
+        </Styled.Wrapper>
+        {touched.name && <Styled.Error>{errors.name}</Styled.Error>}
+        {touched.surname && <Styled.Error>{errors.surname}</Styled.Error>}
+        {touched.email && <Styled.Error>{errors.email}</Styled.Error>}
+        {touched.tel && <Styled.Error>{errors.tel}</Styled.Error>}
+        {touched.dob && <Styled.Error>{errors.dob}</Styled.Error>}
+      </Form>
+    )}
+  </Formik>
 );

--- a/src/modules/cabinet/components/Contacts/CabinetContactsForm.tsx
+++ b/src/modules/cabinet/components/Contacts/CabinetContactsForm.tsx
@@ -5,19 +5,22 @@ import contactsService from '../../../../services/contacts.service';
 import { IContacts } from '../../../../types/contacts';
 import {
   Button as StyledButton,
-  ButtonArrowRight as StyledButtonArrowRight
+  ButtonArrowRight as StyledButtonArrowRight,
+  ButtonWhite as StyledButtonWhite
 } from '../../../common/button/button.styled';
 import * as Styled from './CabinetContactsForm.styled';
 
 interface IProps {
   setContacts: React.Dispatch<React.SetStateAction<IContacts>>;
-  setUpdating: React.Dispatch<React.SetStateAction<boolean>>;
+  isUpdating: boolean;
+  setIsUpdating: React.Dispatch<React.SetStateAction<boolean>>;
   initialValues?: IContacts;
 }
 
 export const CabinetContactsForm: React.FC<IProps> = ({
   setContacts,
-  setUpdating,
+  isUpdating,
+  setIsUpdating,
   initialValues = {
     name: '',
     surname: '',
@@ -28,18 +31,19 @@ export const CabinetContactsForm: React.FC<IProps> = ({
 }) => (
   <Formik
     initialValues={initialValues}
+    enableReinitialize
     validationSchema={contactsValidationSchema}
     onSubmit={(values, { setSubmitting }) => {
       const newContact = { ...values };
       contactsService.contacts = newContact;
       setSubmitting(false);
-      setUpdating(false);
+      setIsUpdating(false);
       setContacts(contactsService.contacts);
     }}
   >
     {({ isSubmitting, errors, touched }) => (
       <Form>
-        <Styled.Wrapper className="for-contacts">
+        <Styled.Wrapper>
           <Styled.Flex>
             <Styled.Column>
               <label htmlFor="name">Ваше ім’я</label>
@@ -79,7 +83,19 @@ export const CabinetContactsForm: React.FC<IProps> = ({
               <label htmlFor="dob">Дата народження</label>
               <Field type="text" name="dob" id="dob" autocomplete="bday" placeholder="8.10.1989" />
               <Styled.ExitBtnContainer>
-                <StyledButtonArrowRight>Вийти</StyledButtonArrowRight>
+                {isUpdating ? (
+                  <StyledButtonWhite
+                    onClick={() => {
+                      contactsService.remove();
+                      setContacts(contactsService.contacts);
+                      setIsUpdating(false);
+                    }}
+                  >
+                    Видалити контакти
+                  </StyledButtonWhite>
+                ) : (
+                  <StyledButtonArrowRight>Вийти</StyledButtonArrowRight>
+                )}
               </Styled.ExitBtnContainer>
             </Styled.Column>
           </Styled.Flex>

--- a/src/modules/cabinet/components/Contacts/CabinetContactsForm.tsx
+++ b/src/modules/cabinet/components/Contacts/CabinetContactsForm.tsx
@@ -11,23 +11,29 @@ import * as Styled from './CabinetContactsForm.styled';
 
 interface IProps {
   setContacts: React.Dispatch<React.SetStateAction<IContacts>>;
+  setUpdating: React.Dispatch<React.SetStateAction<boolean>>;
+  initialValues?: IContacts;
 }
 
-export const CabinetContactsForm: React.FC<IProps> = ({ setContacts }) => (
+export const CabinetContactsForm: React.FC<IProps> = ({
+  setContacts,
+  setUpdating,
+  initialValues = {
+    name: '',
+    surname: '',
+    tel: '',
+    email: '',
+    dob: ''
+  }
+}) => (
   <Formik
-    initialValues={{
-      name: '',
-      surname: '',
-      tel: '',
-      email: '',
-      dob: ''
-    }}
+    initialValues={initialValues}
     validationSchema={contactsValidationSchema}
     onSubmit={(values, { setSubmitting }) => {
       const newContact = { ...values };
       contactsService.contacts = newContact;
-      console.log(values);
       setSubmitting(false);
+      setUpdating(false);
       setContacts(contactsService.contacts);
     }}
   >

--- a/src/modules/cabinet/components/Contacts/CabinetContactsForm.tsx
+++ b/src/modules/cabinet/components/Contacts/CabinetContactsForm.tsx
@@ -43,17 +43,41 @@ export const CabinetContactsForm: React.FC<IProps> = ({
           <Styled.Flex>
             <Styled.Column>
               <label htmlFor="name">Ваше ім’я</label>
-              <Field type="text" name="name" id="name" placeholder="Світлана" />
+              <Field
+                type="text"
+                name="name"
+                id="name"
+                autocomplete="given-name"
+                placeholder="Світлана"
+              />
               <label htmlFor="surname">Ваше прізвище</label>
-              <Field type="text" name="surname" id="surname" placeholder="Світлана" />
+              <Field
+                type="text"
+                name="surname"
+                id="surname"
+                autocomplete="family-name"
+                placeholder="Світлана"
+              />
               <label htmlFor="email">E-mail</label>
-              <Field type="email" name="email" id="email" placeholder="shevSv002@gmail.com" />
+              <Field
+                type="email"
+                name="email"
+                id="email"
+                autocomplete="email"
+                placeholder="shevSv002@gmail.com"
+              />
             </Styled.Column>
             <Styled.Column>
               <label htmlFor="tel">Номер телефону</label>
-              <Field type="tel" name="tel" id="tel" placeholder="+38 068 564 77 99" />
+              <Field
+                type="tel"
+                name="tel"
+                id="tel"
+                autocomplete="tel"
+                placeholder="+38 068 564 77 99"
+              />
               <label htmlFor="dob">Дата народження</label>
-              <Field type="text" name="dob" id="dob" placeholder="8.10.1989" />
+              <Field type="text" name="dob" id="dob" autocomplete="bday" placeholder="8.10.1989" />
               <Styled.ExitBtnContainer>
                 <StyledButtonArrowRight>Вийти</StyledButtonArrowRight>
               </Styled.ExitBtnContainer>

--- a/src/modules/cabinet/pages/Cabinet.styled.ts
+++ b/src/modules/cabinet/pages/Cabinet.styled.ts
@@ -31,12 +31,8 @@ export const Header = styled.h2`
     font-size: clamp(${FONTS.SIZES.m}, 3.7vw, ${FONTS.SIZES.xl});
   }
 `;
-export const MobileTab = styled.h3`
+export const MobileTab = styled.h3<{ $active?: boolean }>`
   display: none;
-  a {
-    color: inherit;
-    text-decoration: none;
-  }
   @media (max-width: ${MEDIA.tablet}px) {
     display: block;
     font-size: clamp(${FONTS.SIZES.s}, 3.3vw, ${FONTS.SIZES.m});
@@ -55,20 +51,23 @@ export const MobileTab = styled.h3`
       height: 6px;
       background: url(${expandIcon}) no-repeat center;
     }
-    &:hover,
-    &.active {
-      cursor: pointer;
-      font-weight: ${FONTS.WEIGHTS.bold};
-    }
-    &.active {
+    ${(props) =>
+      props.$active &&
+      `font-weight: ${FONTS.WEIGHTS.bold};       
       @media (max-width: ${MEDIA.tablet}px) {
         &::after {
           transform: rotate(180deg);
         }
-        &:hover {
-          cursor: default;
-        }
-      }
+      }`}
+  }
+  a {
+    color: inherit;
+    text-decoration: none;
+    width: 100%;
+    height: 100%;
+    &:hover {
+      cursor: pointer;
+      font-weight: ${FONTS.WEIGHTS.bold};
     }
   }
 `;

--- a/src/modules/common/button/button.styled.ts
+++ b/src/modules/common/button/button.styled.ts
@@ -132,3 +132,19 @@ export const ButtonArrowRight = styled.button`
     }
   }
 `;
+
+export const ButtonWhite = styled(ButtonArrowRight)`
+  transition: all 0.2s linear;
+  color: ${COLORS.accent};
+  &:hover {
+    background-color: ${COLORS.accent};
+    color: ${COLORS.white};
+    border-color: ${COLORS.white};
+  }
+  &::before {
+    display: none;
+  }
+  &:hover::before {
+    transform: none;
+  }
+`;

--- a/src/schemas/contacts.schema.ts
+++ b/src/schemas/contacts.schema.ts
@@ -1,0 +1,9 @@
+import { object, string } from 'yup';
+
+export const contactsValidationSchema = object().shape({
+  name: string().min(2).max(40).required("Ім'я - обов'язкове поле вводу!"),
+  surname: string().min(2).max(40).required('Прізвище - обов`язкове поле вводу!'),
+  tel: string().min(1).max(15).required('Телефон - обов`язкове поле вводу!'),
+  email: string().min(1).max(40).required('Електронна пошта - обов`язкове поле вводу!'),
+  dob: string().min(9).max(40)
+});

--- a/src/services/address.service.ts
+++ b/src/services/address.service.ts
@@ -1,5 +1,6 @@
+import { v4 as uuidv4 } from 'uuid';
 import STORAGE_KEYS from '../constants/storageKeys';
-import { IAddNewAddress, IAddress } from '../types/address';
+import { IAddNewAddress, IAddress, IUpdateAddress } from '../types/address';
 
 class AddressService {
   get addresses() {
@@ -11,8 +12,8 @@ class AddressService {
     localStorage.setItem(STORAGE_KEYS.address, JSON.stringify(addresses));
   }
 
-  getById(id: number) {
-    return this.addresses.find((address) => address.id === id);
+  getByUUID(uuid: string) {
+    return this.addresses.find((address) => address.uuid === uuid);
   }
 
   private getNextId() {
@@ -21,6 +22,10 @@ class AddressService {
     }
     const ids = this.addresses.map((address) => address.id);
     return Math.max(...ids) + 1;
+  }
+
+  private generateUUID(): string {
+    return uuidv4();
   }
 
   private recalculateIds() {
@@ -34,29 +39,30 @@ class AddressService {
   }
 
   add(address: IAddNewAddress) {
-    const addressWithId = { ...address, id: this.getNextId() };
-    this.addresses = [...this.addresses, addressWithId];
+    const newAddress = { ...address, id: this.getNextId(), uuid: this.generateUUID() };
+    this.addresses = [...this.addresses, newAddress];
   }
 
-  remove(id: number) {
-    const foundAddress = this.getById(id);
+  remove(uuid: string) {
+    const foundAddress = this.getByUUID(uuid);
     if (foundAddress) {
-      this.addresses = this.addresses.filter((address) => address.id !== id);
+      this.addresses = this.addresses.filter((address) => address.uuid !== uuid);
       this.recalculateIds();
     }
   }
 
-  update(address: IAddress) {
+  update(address: IUpdateAddress) {
     const { addresses } = this;
-    const foundAddress = this.getById(address.id);
+    const foundAddress = this.getByUUID(address.uuid);
     if (foundAddress) {
       const updatedAddress = { ...foundAddress, ...address };
       this.addresses = addresses.map((item) => {
-        if (item.id === address.id) {
+        if (item.uuid === address.uuid) {
           return updatedAddress;
         }
         return item;
       });
+      this.recalculateIds();
     }
   }
 }

--- a/src/services/contacts.service.ts
+++ b/src/services/contacts.service.ts
@@ -1,12 +1,5 @@
 import STORAGE_KEYS from '../constants/storageKeys';
-
-interface IContact {
-  name: string;
-  surname: string;
-  tel: string;
-  email: string;
-  dob?: string;
-}
+import { IContacts } from '../types/contacts';
 
 class ContactsService {
   get contacts() {
@@ -14,12 +7,12 @@ class ContactsService {
     return contacts ? JSON.parse(contacts) : { name: '', surname: '', tel: '', email: '', dob: '' };
   }
 
-  set contacts(contacts: IContact) {
+  set contacts(contacts: IContacts) {
     const contactsString = JSON.stringify(contacts);
     sessionStorage.setItem(STORAGE_KEYS.contacts, contactsString);
   }
 
-  update(updateInfo: IContact) {
+  update(updateInfo: IContacts) {
     const { contacts } = this;
     const newContact = { ...contacts, ...updateInfo };
     this.contacts = newContact;

--- a/src/services/contacts.service.ts
+++ b/src/services/contacts.service.ts
@@ -1,0 +1,34 @@
+import STORAGE_KEYS from '../constants/storageKeys';
+
+interface IContact {
+  name: string;
+  surname: string;
+  tel: string;
+  email: string;
+  dob?: string;
+}
+
+class ContactsService {
+  get contacts() {
+    const contacts = sessionStorage.getItem(STORAGE_KEYS.contacts);
+    return contacts ? JSON.parse(contacts) : { name: '', surname: '', tel: '', email: '', dob: '' };
+  }
+
+  set contacts(contacts: IContact) {
+    const contactsString = JSON.stringify(contacts);
+    sessionStorage.setItem(STORAGE_KEYS.contacts, contactsString);
+  }
+
+  update(updateInfo: IContact) {
+    const { contacts } = this;
+    const newContact = { ...contacts, ...updateInfo };
+    this.contacts = newContact;
+  }
+
+  remove() {
+    this.contacts = { name: '', surname: '', tel: '', email: '', dob: '' };
+  }
+}
+const contactsService = new ContactsService();
+
+export default contactsService;

--- a/src/types/address.ts
+++ b/src/types/address.ts
@@ -8,9 +8,20 @@ export interface IAddNewAddress {
 
 export interface IAddress {
   id: number;
+  uuid: string;
   city: string;
   street: string;
   house: string;
   apartment?: string;
   postal: string;
+}
+
+export interface IUpdateAddress {
+  id?: number;
+  uuid: string;
+  city?: string;
+  street?: string;
+  house?: string;
+  apartment?: string;
+  postal?: string;
 }

--- a/src/types/contacts.ts
+++ b/src/types/contacts.ts
@@ -1,0 +1,7 @@
+export interface IContacts {
+  name: string;
+  surname: string;
+  tel: string;
+  email: string;
+  dob?: string;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2187,6 +2187,11 @@
   resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.3.tgz#a136f83b0758698df454e328759dbd3d44555311"
   integrity sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g==
 
+"@types/uuid@^9.0.7":
+  version "9.0.7"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-9.0.7.tgz#b14cebc75455eeeb160d5fe23c2fcc0c64f724d8"
+  integrity sha512-WUtIVRUZ9i5dYXefDEAI7sh9/O7jGvHg7Df/5O/gtH3Yabe5odI3UWopVR1qbPXQtvOxWu3mM4XxlYeZtMWF4g==
+
 "@types/ws@^8.5.1":
   version "8.5.4"
   resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.5.4.tgz#bb10e36116d6e570dd943735f86c933c1587b8a5"
@@ -9290,6 +9295,11 @@ uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
+uuid@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
+  integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
 
 v8-to-istanbul@^8.1.0:
   version "8.1.1"


### PR DESCRIPTION
# Pull Request

## Description
This pull request includes changes related to the Cabinet Address and Cabinet Contacts modules.

## Cabinet Address Module Updates

1. **Bug Fixes:**
   - Fixed user story when an address in updating state is removed by the user, but the form doesn't reset

2. **Removal Feature:**
   - Added the ability to remove contacts in the update contact form

3. **Autocomplete Feature:**
   - Added autocomplete functionality to address and contact forms

4. **Visual Improvements:**
   - Corrected address visualization
   - Refactored to use props instead of classname in the mobile tab

5. **Logic Enhancements:**
   - Added logic to separate reading from updating or adding contacts in the cabinet
   - Added visualizations when updating addresses in a block
   - Added UUID generation and improved identification for addresses

## Cabinet Contacts Module Updates

1. **Formik Integration:**
   - Added Formik logic to contacts form

2. **Contacts Service:**
   - Added contacts service

3. **Styling Refinement:**
   - Refactored to pass props through styled components instead of using classname conditions

## Bug Fixes and General Improvements

- Fixed an issue with Chrome Dev Tools complaining about the meta tag in HTML
